### PR TITLE
Clarify model names

### DIFF
--- a/src/models/data.ts
+++ b/src/models/data.ts
@@ -1,9 +1,9 @@
 // Data is a unit of information about a business
-export interface IData {
+export interface Data {
 	source: string;
 }
 
 // Extracted<DataType> contains all extractions from a piece of data of that type
-export interface IExtracted<DataType extends IData> {
+export interface Extracted<DataType extends Data> {
 	origin: DataType;
 }

--- a/src/models/data.ts
+++ b/src/models/data.ts
@@ -3,7 +3,15 @@ export interface Data {
 	source: string;
 }
 
-// Extracted<DataType> contains all extractions from a piece of data of that type
-export interface Extracted<DataType extends Data> {
+export interface Extraction {
+	confidence: number;
+}
+
+// Extracted<DataType> contains all extractions from a piece of data of the given type
+export interface Extracted<
+	DataType extends Data,
+	ExtractionCollectionType extends Record<string, Array<Extraction>>
+> {
 	origin: DataType;
+	extractions: ExtractionCollectionType;
 }

--- a/src/models/data.ts
+++ b/src/models/data.ts
@@ -3,7 +3,7 @@ export interface IData {
 	source: string;
 }
 
-// Extracted<Data> contains all extractions from a piece of data of that type
-export interface IExtracted<Data extends IData> {
-	origin: Data;
+// Extracted<DataType> contains all extractions from a piece of data of that type
+export interface IExtracted<DataType extends IData> {
+	origin: DataType;
 }

--- a/src/models/data_models/image.ts
+++ b/src/models/data_models/image.ts
@@ -1,11 +1,11 @@
-import { IData, IExtracted } from '../data';
+import { Data, Extracted } from '../data';
 
 // A picture of something to do with a business
-export interface IImage extends IData {
+export interface Image extends Data {
 	// TODO (Benny): probably a bunch of other fields belong here
 }
 
 // An ExtractedImage contains all the extractions for a single image
-export interface IExtractedImage extends IExtracted<IImage> {
+export interface ExtractedImage extends Extracted<Image> {
 	// TODO (Josh): probably a bunch of other fields belong here
 }

--- a/src/models/data_models/image.ts
+++ b/src/models/data_models/image.ts
@@ -1,4 +1,4 @@
-import { Data, Extracted } from '../data';
+import { Data, Extracted, Extraction } from '../data';
 
 // A picture of something to do with a business
 export interface Image extends Data {
@@ -6,6 +6,6 @@ export interface Image extends Data {
 }
 
 // An ExtractedImage contains all the extractions for a single image
-export interface ExtractedImage extends Extracted<Image> {
+export interface ExtractedImage extends Extracted<Image, Record<string, Array<Extraction>>> {
 	// TODO (Josh): probably a bunch of other fields belong here
 }

--- a/src/models/data_models/index.ts
+++ b/src/models/data_models/index.ts
@@ -1,1 +1,1 @@
-export { IImage, IExtractedImage } from './image';
+export { IImage as Image, IExtractedImage as ExtractedImage } from './image';

--- a/src/models/data_models/index.ts
+++ b/src/models/data_models/index.ts
@@ -1,1 +1,1 @@
-export { IImage as Image, IExtractedImage as ExtractedImage } from './image';
+export { Image, ExtractedImage } from './image';

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -1,2 +1,2 @@
-export { IData as Data, IExtracted as Extracted } from './data';
-export { IEvidenceSource as EvidenceSource, Evidence, Inference as Inference } from './insight';
+export { Data, Extracted } from './data';
+export { EvidenceSource, Evidence, Inference } from './insight';

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -1,2 +1,2 @@
-export { Data, Extracted } from './data';
+export { Data, Extraction, Extracted } from './data';
 export { EvidenceSource, Evidence, Inference } from './insight';

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -1,2 +1,2 @@
 export { IData as Data, IExtracted as Extracted } from './data';
-export { IEvidenceSource as EvidenceSource, Evidence, Insight } from './insight';
+export { IEvidenceSource as EvidenceSource, Evidence, Inference as Inference } from './insight';

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -1,2 +1,7 @@
-export { IData, IExtracted } from './data';
-export { IEvidenceSource, Evidence, IEvidenceCollection, Insight } from './insight';
+export { IData as Data, IExtracted as Extracted } from './data';
+export {
+	IEvidenceSource as EvidenceSource,
+	Evidence,
+	IEvidenceCollection as EvidenceCollection,
+	Insight,
+} from './insight';

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -1,7 +1,2 @@
 export { IData as Data, IExtracted as Extracted } from './data';
-export {
-	IEvidenceSource as EvidenceSource,
-	Evidence,
-	IEvidenceCollection as EvidenceCollection,
-	Insight,
-} from './insight';
+export { IEvidenceSource as EvidenceSource, Evidence, Insight } from './insight';

--- a/src/models/insight.ts
+++ b/src/models/insight.ts
@@ -6,13 +6,8 @@ export type Evidence<EvidenceSource extends IEvidenceSource> = {
 	reason: string;
 };
 
-// An EvidenceCollection's fields contain different types of Evidence
-export interface IEvidenceCollection {
-	[evidenceType: string]: Array<Evidence<IEvidenceSource>>;
-}
-
 // An insight is a value about a business, with evidence for how it was inferred
-export type Insight<Value, EvidenceCollection extends IEvidenceCollection> = {
+export type Insight<Value, EvidenceCollection extends Record<string, Array<Evidence<IEvidenceSource>>>> = {
 	value: Value;
 	confidence: number;
 	evidence: EvidenceCollection;

--- a/src/models/insight.ts
+++ b/src/models/insight.ts
@@ -1,7 +1,7 @@
-export interface IEvidenceSource {}
+export interface EvidenceSource {}
 
 // Evidence cites a piece of data or extraction to explain why an insight was made
-export type Evidence<SourceType extends IEvidenceSource> = {
+export type Evidence<SourceType extends EvidenceSource> = {
 	source: SourceType;
 	reason: string;
 };
@@ -9,7 +9,7 @@ export type Evidence<SourceType extends IEvidenceSource> = {
 // An inference is a piece of insight about a business, with evidence for how it was inferred
 export type Inference<
 	InsightType,
-	EvidenceCollectionType extends Record<string, Array<Evidence<IEvidenceSource>>>
+	EvidenceCollectionType extends Record<string, Array<Evidence<EvidenceSource>>>
 > = {
 	insight: InsightType;
 	confidence: number;

--- a/src/models/insight.ts
+++ b/src/models/insight.ts
@@ -6,12 +6,12 @@ export type Evidence<SourceType extends IEvidenceSource> = {
 	reason: string;
 };
 
-// An insight is a value about a business, with evidence for how it was inferred
-export type Insight<
-	InferenceType,
+// An inference is a piece of insight about a business, with evidence for how it was inferred
+export type Inference<
+	InsightType,
 	EvidenceCollectionType extends Record<string, Array<Evidence<IEvidenceSource>>>
 > = {
-	inference: InferenceType;
+	insight: InsightType;
 	confidence: number;
 	evidence: EvidenceCollectionType;
 };

--- a/src/models/insight.ts
+++ b/src/models/insight.ts
@@ -1,17 +1,17 @@
 export interface IEvidenceSource {}
 
 // Evidence cites a piece of data or extraction to explain why an insight was made
-export type Evidence<EvidenceSource extends IEvidenceSource> = {
-	source: EvidenceSource;
+export type Evidence<SourceType extends IEvidenceSource> = {
+	source: SourceType;
 	reason: string;
 };
 
 // An insight is a value about a business, with evidence for how it was inferred
 export type Insight<
-	Inference,
-	EvidenceCollection extends Record<string, Array<Evidence<IEvidenceSource>>>
+	InferenceType,
+	EvidenceCollectionType extends Record<string, Array<Evidence<IEvidenceSource>>>
 > = {
-	inference: Inference;
+	inference: InferenceType;
 	confidence: number;
-	evidence: EvidenceCollection;
+	evidence: EvidenceCollectionType;
 };

--- a/src/models/insight.ts
+++ b/src/models/insight.ts
@@ -7,8 +7,11 @@ export type Evidence<EvidenceSource extends IEvidenceSource> = {
 };
 
 // An insight is a value about a business, with evidence for how it was inferred
-export type Insight<Value, EvidenceCollection extends Record<string, Array<Evidence<IEvidenceSource>>>> = {
-	value: Value;
+export type Insight<
+	Inference,
+	EvidenceCollection extends Record<string, Array<Evidence<IEvidenceSource>>>
+> = {
+	inference: Inference;
 	confidence: number;
 	evidence: EvidenceCollection;
 };


### PR DESCRIPTION
The goal of this pull request is to clarify the names of various models, and ensure that they adhere to the TypeScript Handbook. In particular, this includes removing the `I` prefix from Interface names.