### PR TITLE
Actually implement the word2vec interpretation provider

### DIFF
--- a/src/providers/interpretation_providers/interpretationProvider.ts
+++ b/src/providers/interpretation_providers/interpretationProvider.ts
@@ -5,10 +5,8 @@ export interface EvidenceCollection extends Record<string, Array<Evidence<Eviden
 	images: Array<Evidence<ExtractedImage>>;
 }
 
-export interface BusinessInsights {
-	capacity?: Inference<number, EvidenceCollection>;
-	hasDelivery?: Inference<boolean, EvidenceCollection>;
-	servesAlcohol?: Inference<boolean, EvidenceCollection>;
+export interface BusinessInferences {
+	servesAlcohol: Inference<boolean, EvidenceCollection>;
 }
 
 export interface InterpretationParams {
@@ -16,5 +14,5 @@ export interface InterpretationParams {
 }
 
 export interface InterpretationProvider {
-	interpret(information: InterpretationParams): BusinessInsights;
+	interpret(information: InterpretationParams): BusinessInferences;
 }

--- a/src/providers/interpretation_providers/mockInterpretationProvider.ts
+++ b/src/providers/interpretation_providers/mockInterpretationProvider.ts
@@ -1,4 +1,4 @@
-import { InterpretationProvider, BusinessInsights, InterpretationParams } from './interpretationProvider';
+import { InterpretationProvider, BusinessInferences, InterpretationParams } from './interpretationProvider';
 
 export interface MockConfig {}
 
@@ -9,7 +9,7 @@ export class MockInterpretationProvider implements InterpretationProvider {
 		return new MockInterpretationProvider();
 	}
 
-	public interpret(information: InterpretationParams): BusinessInsights {
+	public interpret(information: InterpretationParams): BusinessInferences {
 		return {
 			hasDelivery: {
 				insight: true,

--- a/src/providers/interpretation_providers/mockInterpretationProvider.ts
+++ b/src/providers/interpretation_providers/mockInterpretationProvider.ts
@@ -11,13 +11,6 @@ export class MockInterpretationProvider implements InterpretationProvider {
 
 	public interpret(information: InterpretationParams): BusinessInferences {
 		return {
-			hasDelivery: {
-				insight: true,
-				confidence: 0.7,
-				evidence: {
-					images: [],
-				},
-			},
 			servesAlcohol: {
 				insight: false,
 				confidence: 0.2,


### PR DESCRIPTION
For simplicity, let's scale things back to just detecting alcohol for now

Tested using the following `main` script:

```ts
import { getExtractionProvider } from './providers/extraction_providers/extractionProviderFactory';
import { getInterpretationProvider } from './providers/interpretation_providers/interpretationProviderFactory';

const main = async () => {
	const extractionProvider = getExtractionProvider({
		extractionProviderName: "MOCK",
	})
	const interpretationProvider = await getInterpretationProvider({
		interpretationProviderName: "WORD2VEC",
		interpretationProviderConfig: {
			modelName: "glove.6B.50d.txt",
			similarityThreshold: 0.7,
		}
	});

	const extractions = extractionProvider.extract([]);
	console.log(extractions)
	const inferences = interpretationProvider.interpret({
		images: extractions
	})
	console.log(inferences)

	for (const image of inferences.servesAlcohol.evidence.images) {
		console.log(image);
	}
};

main();
```